### PR TITLE
Making it possible to return nested non existing directories with `rewrite` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,11 +121,12 @@ copy.one = function copyOne(fp, dest, options, cb) {
   }
 
   var opts = defaults(fp, dest, options);
-  mkdir(dest, opts, function (err) {
+  var destFile = opts.rewrite(fp, dest);
+  mkdir(path.dirname(destFile), opts, function (err) {
     if (err) return cb(err);
 
     try {
-      copy.base(fp, opts.rewrite(fp, dest), opts);
+      copy.base(fp, destFile, opts);
       return cb();
     } catch(err) {
       return cb(err);
@@ -146,9 +147,10 @@ copy.one = function copyOne(fp, dest, options, cb) {
 
 copy.oneSync = function copyOneSync(fp, dest, options) {
   var opts = defaults(fp, dest, options);
+  var destFile = opts.rewrite(fp, dest);
   try {
-    mkdir.sync(dest, opts);
-    copy.base(fp, opts.rewrite(fp, dest));
+    mkdir.sync(path.dirname(destFile), opts);
+    copy.base(fp, destFile);
   } catch (err) {
     throw new Error(err);
   }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "license": "MIT",
   "files": [
-    "index.js"
+    "index.js",
+    "recurse.js"
   ],
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Copying a complete directory including subdirectories does not work at the moment.

**Example:**

Directory structure:

```
/source/
└── src
    └── index.js
```

And a `rewrite` option like so:

``` javascript
var path = require('path');
var cp = require('copy');

cp.dir('/source', '/dest', {
  rewrite: function (f, d) {
    return path.resolve(d, path.relative(src, f));
  }
}, cb)
```

Will throw an `ENOENT` error for the `/dest/src` directory.

This PR addresses that by calling `mkdirp` for each file's destination folder, instead of only for the top most destination folder.

_Note:_ I also think that a `rewrite` function like the one above would be a more logical default, instead of flattening like now, what do you think?
