### PR TITLE
Expose the copy function as a cli command

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+
+var copy = require('../index');
+
+var patterns = process.argv[2],
+    dir = process.argv[3];
+
+if (! patterns || ! dir) {
+  console.log('Usage: copy <patterns> <dir>');
+} else {
+  copy(patterns, dir, function(err, file) {
+    if (err) {
+      console.error(err);
+      process.exit(1);
+    } else {
+      process.exit(0);
+    }
+  });
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "index.js",
     "lib/"
   ],
+  "bin": {
+    "copy": "lib/cli.js"
+  },
   "main": "index.js",
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
This PR exposes the copy function via the command line by registering a `bin` property in the package.json and applying the first 2 arguments on the command line to the `patterns` and `dir` parameters respectively.  The return code of the cli script respects the `err` parameter of the callback, only returning a `0` value when the `err` is empty.

This is an initial implementation, a more rigorous treatment would expose the `copy` options object as additional arguments/options in the cli.
