### PR TITLE
Add `copy-cli` for Windows. Fixes #13

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   ],
   "main": "index.js",
   "bin": {
-    "copy": "bin/cli.js"
+    "copy": "bin/cli.js",
+    "copy-cli": "bin/cli.js"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
The CLI for this package doesn't work properly in Windows. The reason is very simple: Windows already has a [copy](http://www.computerhope.com/copyhlp.htm) command.

Since NPM doesn't override the command, we can't use the CLI from this package. Each time we run "copy" we will actually run the native "copy" command.

The native copy works fine in some situations, but not with globs. (See #13)

The solution I find to this is the same used by Sindre Sorhus in his [del-cli](https://github.com/sindresorhus/del-cli) package.

Since "del" is a native Windows command too, he created a new alias for the CLI usage: `del-cli`.

I thought we could use the same solution for this package, and make `copy-cli` available for those who unfortunately have to use Windows.

I hope you accept it. Thank you!
